### PR TITLE
make the memory::string support clone function

### DIFF
--- a/arena/arena.hpp
+++ b/arena/arena.hpp
@@ -20,25 +20,26 @@
 
 #pragma once
 
-#include <boost/core/demangle.hpp>       // for demangle
-#include <stdint.h>                      // for uint64_t, uint8_t
-#include <cassert>                       // for assert
-#include <concepts>
-#include <cstdlib>                       // for free, malloc, size_t
-#include <iostream>                      // for endl, basic_ostream, cerr
-#include <limits>                        // for numeric_limits
-#include <memory_resource>               // for memory_resource
-#include <type_traits>                   // for false_type, is_standard_layout
-#include <typeinfo>                      // for bad_cast, type_info
-#include <utility>                       // for exchange, forward
-#include <exception>                     // for type_info
-#include <new>                           // for operator new, bad_alloc
-#include <string>                        // for allocator, operator<<, string
-#include <unordered_map>                 // for polymorphic_allocator
+#include <stdint.h>  // for uint64_t, uint8_t
 
-#include "arenahelper.hpp"               // for ArenaHelper
-#include "fmt/core.h"                    // for format
-#include "align.hpp"                     // for AlignUpTo
+#include <boost/core/demangle.hpp>  // for demangle
+#include <cassert>                  // for assert
+#include <concepts>
+#include <cstdlib>          // for free, malloc, size_t
+#include <exception>        // for type_info
+#include <iostream>         // for endl, basic_ostream, cerr
+#include <limits>           // for numeric_limits
+#include <memory_resource>  // for memory_resource
+#include <new>              // for operator new, bad_alloc
+#include <string>           // for allocator, operator<<, string
+#include <type_traits>      // for false_type, is_standard_layout
+#include <typeinfo>         // for bad_cast, type_info
+#include <unordered_map>    // for polymorphic_allocator
+#include <utility>          // for exchange, forward
+
+#include "align.hpp"        // for AlignUpTo
+#include "arenahelper.hpp"  // for ArenaHelper
+#include "fmt/core.h"       // for format
 
 #if defined(__GNUC__) && (__GNUC__ >= 11)
 #include <source_location>

--- a/arena/metrics.hpp
+++ b/arena/metrics.hpp
@@ -20,20 +20,20 @@
 
 #pragma once
 
+#include <bits/chrono.h>  // for operator""ms, duration, stea...
+#include <fmt/core.h>     // for format
 
-#include <fmt/core.h>                    // for format
-#include <bits/chrono.h>                 // for operator""ms, duration, stea...
-#include <atomic>                        // for atomic, memory_order, memory...
-#include <unordered_map>                 // for unordered_map, operator==
-#include <utility>                       // for tuple_element<>::type
-#include <array>                         // for array, array<>::value_type
-#include <compare>                       // for operator<=, strong_ordering
-#include <cstdint>                       // for uint64_t, uint32_t
-#include <memory>                        // for allocator, unique_ptr
-#include <string>                        // for string, char_traits, hash
-#include <typeinfo>                      // for type_info
+#include <array>          // for array, array<>::value_type
+#include <atomic>         // for atomic, memory_order, memory...
+#include <compare>        // for operator<=, strong_ordering
+#include <cstdint>        // for uint64_t, uint32_t
+#include <memory>         // for allocator, unique_ptr
+#include <string>         // for string, char_traits, hash
+#include <typeinfo>       // for type_info
+#include <unordered_map>  // for unordered_map, operator==
+#include <utility>        // for tuple_element<>::type
 
-#include "arena.hpp"                     // for Arena
+#include "arena.hpp"  // for Arena
 
 #if defined(__GNUC__) && (__GNUC__ >= 11)
 #include <source_location>

--- a/memory.hpp
+++ b/memory.hpp
@@ -26,13 +26,14 @@ constexpr auto is_digit(char chr) noexcept -> bool { return chr <= '9' && chr >=
 
 constexpr auto stoi_impl(const char* str, uint64_t value = 0) -> uint64_t {
     // NOLINTNEXTLINE
-    return (*str != '\0') ? is_digit(*str) ? stoi_impl(str + 1, static_cast<uint64_t>(*str - '0') + value * 10)
-                                 : throw "compile-time-error: not a digit" // NOLINT: can not be throw in real world.
-                : value;
+    return (*str != '\0') ? is_digit(*str)
+                              ? stoi_impl(str + 1, static_cast<uint64_t>(*str - '0') + value * 10)
+                              : throw "compile-time-error: not a digit"  // NOLINT: can not be throw in real world.
+                          : value;
 }
 
 constexpr auto stoi(const char* str) -> uint64_t { return stoi_impl(str); }
-constexpr uint64_t kilo = (1ULL<<10ULL);
+constexpr uint64_t kilo = (1ULL << 10ULL);
 // NOLINTNEXTLINE(bugprone-exception-escape)
 inline constexpr auto operator""_KB(const char* uint_str) noexcept -> uint64_t { return stoi(uint_str) * kilo; }
 // NOLINTNEXTLINE(bugprone-exception-escape)

--- a/string.hpp
+++ b/string.hpp
@@ -1110,13 +1110,20 @@ class basic_string
         return assign(init_list.begin(), init_list.end());  // NOLINT
     }
 
+    /*
+     * with clone function, caller can get a truely deep copy string from the original string, default copy constructor
+     * and copy assignment operator will get a CoW string if the string in the large mode(size > 255). this feature will
+     * make string safe in cross cpu-core argument passing. because memory::string do not use atomic int, so the
+     * refCounted ++/-- is not thread safe.
+     */
     auto clone() const -> basic_string {
         if (store_.category() == Storage::Category::isLarge) {
-            // copy cstr
+            // call copy constructor
             basic_string rst(*this);
             rst.store_.unshare();
             return rst;
         }
+        // directly call copy constructor.
         return {*this};
     }
 

--- a/string.hpp
+++ b/string.hpp
@@ -2,30 +2,31 @@
 
 #pragma once
 
+#include <ctype.h>     // for isspace
+#include <fmt/core.h>  // for string_view, formatter, formatter<>...
 #include <fmt/format.h>
-#include <ctype.h>                // for isspace
-#include <fmt/core.h>             // for string_view, formatter, formatter<>...
-#include <stdint.h>               // for uint8_t, int64_t, int32_t
-#include <stdio.h>                // for getline, ssize_t
-#include <stdlib.h>               // for free, malloc, realloc
-#include <algorithm>              // for min, max, copy, fill
-#include <cassert>                // for assert
-#include <cstddef>                // for size_t, offsetof
-#include <cstring>                // for memcpy, memcmp, memmove, memset
-#include <iosfwd>                 // for basic_istream
-#include <limits>                 // for numeric_limits
-#include <stdexcept>              // for out_of_range, length_error, logic_e...
-#include <string>                 // for basic_string, allocator, string
-#include <string_view>            // for hash, basic_string_view
-#include <type_traits>            // for integral_constant, true_type, is_same
-#include <utility>                // for move, make_pair, pair
-#include <bit>                    // for endian, endian::little, endian::native
-#include <functional>             // for less_equal
-#include <initializer_list>       // for initializer_list
-#include <istream>                // for basic_istream, basic_ostream, __ost...
-#include <iterator>               // for forward_iterator_tag, input_iterato...
-#include <memory>                 // for allocator_traits
-#include <new>                    // for bad_alloc, operator new
+#include <stdint.h>  // for uint8_t, int64_t, int32_t
+#include <stdio.h>   // for getline, ssize_t
+#include <stdlib.h>  // for free, malloc, realloc
+
+#include <algorithm>         // for min, max, copy, fill
+#include <bit>               // for endian, endian::little, endian::native
+#include <cassert>           // for assert
+#include <cstddef>           // for size_t, offsetof
+#include <cstring>           // for memcpy, memcmp, memmove, memset
+#include <functional>        // for less_equal
+#include <initializer_list>  // for initializer_list
+#include <iosfwd>            // for basic_istream
+#include <istream>           // for basic_istream, basic_ostream, __ost...
+#include <iterator>          // for forward_iterator_tag, input_iterato...
+#include <limits>            // for numeric_limits
+#include <memory>            // for allocator_traits
+#include <new>               // for bad_alloc, operator new
+#include <stdexcept>         // for out_of_range, length_error, logic_e...
+#include <string>            // for basic_string, allocator, string
+#include <string_view>       // for hash, basic_string_view
+#include <type_traits>       // for integral_constant, true_type, is_same
+#include <utility>           // for move, make_pair, pair
 
 #include "arena/arenahelper.hpp"  // for ArenaFullManagedTag
 #include "xxhash.h"               // for XXH32

--- a/string.hpp
+++ b/string.hpp
@@ -302,6 +302,9 @@ template <class Char>
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class string_core
 {
+    template <typename E, class T, class A, class Storage>
+    friend class basic_string;
+
    public:
     string_core() noexcept { reset(); }
 
@@ -1104,6 +1107,16 @@ class basic_string
 
     auto operator=(std::initializer_list<value_type> init_list) -> basic_string& {
         return assign(init_list.begin(), init_list.end());  // NOLINT
+    }
+
+    auto clone() const -> basic_string {
+        if (store_.category() == Storage::Category::isLarge) {
+            // copy cstr
+            basic_string rst(*this);
+            rst.store_.unshare();
+            return rst;
+        }
+        return {*this};
     }
 
     // NOLINTNEXTLINE

--- a/test/arena_test.cc
+++ b/test/arena_test.cc
@@ -20,18 +20,18 @@
 
 #include "arena/arena.hpp"
 
-#include <cstring>               // for memcmp, strcmp
-#include <cstdlib>                // for free, malloc
-#include <memory>                 // for allocator, make_unique, unique_ptr
-#include <string>                 // for string, operator==, basic_string
-#include <typeinfo>               // for type_info
-#include <vector>                 // for vector, vector<>::allocator_type
-#include <cstdint>                // for uint64_t
+#include <cstdint>   // for uint64_t
+#include <cstdlib>   // for free, malloc
+#include <cstring>   // for memcmp, strcmp
+#include <memory>    // for allocator, make_unique, unique_ptr
+#include <string>    // for string, operator==, basic_string
+#include <typeinfo>  // for type_info
+#include <vector>    // for vector, vector<>::allocator_type
 #ifndef _MULTI_THREAD_TEST_
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #endif
-#include "doctest/doctest.h"      // for binary_assert, CHECK_EQ, TestCase
 #include "arena/arenahelper.hpp"  // for ArenaFullManagedTag, ArenaManagedCr...
+#include "doctest/doctest.h"      // for binary_assert, CHECK_EQ, TestCase
 
 using stdb::memory::align::AlignUp;
 using stdb::memory::align::AlignUpTo;
@@ -1200,11 +1200,13 @@ TEST_CASE("ArenaTest.Create_Object_with_allocator") {
     CHECK_EQ(a.check(obj->name.c_str()), ArenaContainStatus::BlockUsed);
 }
 
-struct simple_test_struct {
+struct simple_test_struct
+{
     int _s;
 };
 
-struct simple_test_struct_with_tag {
+struct simple_test_struct_with_tag
+{
     int _s;
     ArenaFullManagedTag;
 };
@@ -1213,6 +1215,5 @@ TEST_CASE("ArenaTagOverhead") {
     CHECK_EQ(sizeof(simple_test_struct), 4);
     CHECK_EQ(sizeof(simple_test_struct_with_tag), 4);
 }
-
 
 }  // namespace stdb::memory

--- a/test/metrics_test.cc
+++ b/test/metrics_test.cc
@@ -19,8 +19,8 @@
 */
 #include "arena/metrics.hpp"
 
-#include <thread>             // for thread
-#include <cstdlib>            // for free, malloc
+#include <cstdlib>  // for free, malloc
+#include <thread>   // for thread
 
 #include "arena/arena.hpp"    // for Arena, Arena::Options
 #include "doctest/doctest.h"  // for binary_assert, CHECK_EQ, TestCase, CHECK

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -1573,6 +1573,8 @@ TEST_CASE("string::Clone") {
         CHECK_EQ(l1.length(), 5000);
         auto l2_cow = l1;
         auto l2 = l1.clone();
+        CHECK_EQ(l1, l2);
+        CHECK_EQ(l1, l2_cow);
         CHECK_EQ(l2_cow.data(), l1.data());
         CHECK_NE(l2.data(), l1.data());
     }

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -1,19 +1,20 @@
 #include "string.hpp"
 
-#include <fmt/core.h>         // for format
-#include <bits/chrono.h>      // for duration, system_clock, system_clock::t...
-#include <cxxabi.h>           // for __forced_unwind
-#include <sys/types.h>        // for uint
-#include <algorithm>          // for for_each
-#include <atomic>             // for atomic, __atomic_base
-#include <cstddef>            // for size_t
-#include <iterator>           // for move_iterator, make_move_iterator, oper...
-#include <list>               // for list, operator==, _List_iterator, _List...
-#include <random>             // for mt19937, uniform_int_distribution
-#include <sstream>            // for operator<<, basic_istream, basic_string...
-#include <type_traits>        // for is_same
-#include <iostream>           // for cout
-#include <vector>             // for vector
+#include <bits/chrono.h>  // for duration, system_clock, system_clock::t...
+#include <cxxabi.h>       // for __forced_unwind
+#include <fmt/core.h>     // for format
+#include <sys/types.h>    // for uint
+
+#include <algorithm>    // for for_each
+#include <atomic>       // for atomic, __atomic_base
+#include <cstddef>      // for size_t
+#include <iostream>     // for cout
+#include <iterator>     // for move_iterator, make_move_iterator, oper...
+#include <list>         // for list, operator==, _List_iterator, _List...
+#include <random>       // for mt19937, uniform_int_distribution
+#include <sstream>      // for operator<<, basic_istream, basic_string...
+#include <type_traits>  // for is_same
+#include <vector>       // for vector
 
 #include "arena/arena.hpp"    // for size_t, Arena, Arena::Options
 #include "doctest/doctest.h"  // for binary_assert, CHECK_EQ, TestCase, CHECK
@@ -64,7 +65,7 @@ void clause11_21_4_2_a(String& test) {
 }
 template <class String>
 void clause11_21_4_2_b(String& test) {
-    String test2(test); // NOLINT
+    String test2(test);  // NOLINT
     assert(test2 == test);
 }
 template <class String>
@@ -77,7 +78,7 @@ void clause11_21_4_2_c(String& test) {
     // Technically not required, but all implementations that actually
     // support move will move large strings. Make a guess for 128 as the
     // maximum small string optimization that's reasonable.
-    CHECK_LE(donor.size(), 128); // NOLINT
+    CHECK_LE(donor.size(), 128);  // NOLINT
 }
 template <class String>
 void clause11_21_4_2_d(String& test) {
@@ -174,7 +175,7 @@ void clause11_21_4_2_k(String& test) {
     }
     test = std::move(s);
     if (std::is_same<String, string>::value) {
-        CHECK_LE(s.size(), 128); // NOLINT
+        CHECK_LE(s.size(), 128);  // NOLINT
     }
 }
 template <class String>
@@ -185,7 +186,7 @@ void clause11_21_4_2_l(String& test) {
     for (; i != s.size(); ++i) {
         s[i] = random('a', 'z');
     }
-    test = s.c_str(); // NOLINT
+    test = s.c_str();  // NOLINT
 }
 template <class String>
 void clause11_21_4_2_lprime(String& test) {
@@ -219,9 +220,9 @@ void clause11_21_4_3(String& test) {
     CHECK_EQ(test.size(), test.crend() - test.crbegin());
 
     auto s = test.size();
-    test.resize(size_t(test.end() - test.begin())); // NOLINT
+    test.resize(size_t(test.end() - test.begin()));  // NOLINT
     CHECK_EQ(s, test.size());
-    test.resize(size_t(test.rend() - test.rbegin())); // NOLINT
+    test.resize(size_t(test.rend() - test.rbegin()));  // NOLINT
     CHECK_EQ(s, test.size());
 }
 
@@ -335,7 +336,7 @@ void clause11_21_4_6_2(String& test) {
     randomString(&s, maxString);
     test.append(s.c_str(), random(0, s.size()));
     randomString(&s, maxString);
-    test.append(s.c_str()); // NOLINT
+    test.append(s.c_str());  // NOLINT
     test.append(random(0, maxString), random('a', 'z'));
     std::list<char> lst(RandomList(maxString));
     test.append(lst.begin(), lst.end());
@@ -357,7 +358,7 @@ void clause11_21_4_6_3_a(String& test) {
     // move assign
     test.assign(std::move(s));
     if (std::is_same<String, string>::value) {
-        CHECK_LE(s.size(), 128); // NOLINT
+        CHECK_LE(s.size(), 128);  // NOLINT
     }
 }
 
@@ -382,7 +383,7 @@ void clause11_21_4_6_3_d(String& test) {
     // assign
     String s;
     randomString(&s, maxString);
-    test.assign(s.c_str()); // NOLINT
+    test.assign(s.c_str());  // NOLINT
 }
 
 template <class String>
@@ -421,7 +422,7 @@ void clause11_21_4_6_3_i(String& test) {
 template <class String>
 void clause11_21_4_6_3_j(String& test) {
     // assign from aliased source
-    test.assign(test.c_str()); // NOLINT
+    test.assign(test.c_str());  // NOLINT
 }
 
 template <class String>
@@ -442,7 +443,7 @@ void clause11_21_4_6_4(String& test) {
     randomString(&s, maxString);
     test.insert(random(0, test.size()), s.c_str(), random(0, s.size()));
     randomString(&s, maxString);
-    test.insert(random(0, test.size()), s.c_str()); // NOLINT
+    test.insert(random(0, test.size()), s.c_str());  // NOLINT
     test.insert(random(0, test.size()), random(0, maxString), random('a', 'z'));
     typename String::size_type pos = random(0, test.size());
     typename String::iterator res = test.insert(test.begin() + int(pos), random('a', 'z'));  // NOLINT
@@ -450,12 +451,12 @@ void clause11_21_4_6_4(String& test) {
     std::list<char> lst(RandomList(maxString));
     pos = random(0, test.size());
     // Uncomment below to see a bug in gcc
-    /*res = */ test.insert(test.begin() + int(pos), lst.begin(), lst.end()); // NOLINT
+    /*res = */ test.insert(test.begin() + int(pos), lst.begin(), lst.end());  // NOLINT
     // insert from initializer_list
     std::initializer_list<typename String::value_type> il{'a', 'b', 'c'};
     pos = random(0, test.size());
     // Uncomment below to see a bug in gcc
-    /*res = */ test.insert(test.begin() + int(pos), il); // NOLINT
+    /*res = */ test.insert(test.begin() + int(pos), il);  // NOLINT
 
     // Test with actual input iterators
     std::stringstream ss;
@@ -472,7 +473,7 @@ void clause11_21_4_6_5(String& test) {
     }
     if (!test.empty()) {
         // TODO(longqimin): is erase(end()) allowed?
-        test.erase(test.begin() + int(random(0, test.size() - 1))); // NOLINT
+        test.erase(test.begin() + int(random(0, test.size() - 1)));  // NOLINT
     }
     if (!test.empty()) {
         auto const i = test.begin() + int(random(0, test.size()));  // NOLINT
@@ -1200,7 +1201,9 @@ TEST_CASE("string::testMoveOperatorPlusRhs") {
 // N.B. We behave this way even if the C++ library being used is something
 //      other than libstdc++. Someday if we deem it important to present
 //      identical undefined behavior for other platforms, we can re-visit this.
-TEST_CASE("string::testConstructionFromLiteralZero") { CHECK_THROWS_AS(string s(nullptr), std::logic_error); } // NOLINT
+TEST_CASE("string::testConstructionFromLiteralZero") {
+    CHECK_THROWS_AS(string s(nullptr), std::logic_error);
+}  // NOLINT
 
 TEST_CASE("string::testFixedBugs_D479397") {
     string str(1337, 'f');
@@ -1312,8 +1315,8 @@ TEST_CASE("string::rvalueIterators") {
     // The following test is probably not required by the standard.
     // i.e. this could be in the realm of undefined behavior.
     string b = "123abcXYZ";
-    auto ait = b.begin() + 3; // NOLINT
-    auto Xit = b.begin() + 6; // NOLINT
+    auto ait = b.begin() + 3;  // NOLINT
+    auto Xit = b.begin() + 6;  // NOLINT
     b.replace(ait, b.end(), b.begin(), Xit);
     CHECK_EQ("123123abc", b);  // if things go wrong, you'd get "123123123"
 }
@@ -1324,7 +1327,7 @@ TEST_CASE("string::moveTerminator") {
     string k;
     k = std::move(s);
 
-    CHECK_EQ(0, s.size()); // NOLINT
+    CHECK_EQ(0, s.size());  // NOLINT
     CHECK_EQ('\0', *s.c_str());
 }
 


### PR DESCRIPTION
with clone function, caller can get a truely deep copy string from the original string, default copy constructor and copy assignment operator will get a CoW string if the string in the large mode(size > 255).

this feature will make string safe in cross cpu core argument passing.
because memory::string do not use atomic int, so the refCounted ++/-- is not thread safe.

Resolves CORE-628