### PR TITLE
replace bits/chrono.h with chrono

### DIFF
--- a/.github/workflows/test-linux-clang.yml
+++ b/.github/workflows/test-linux-clang.yml
@@ -1,0 +1,39 @@
+name: Linux (clang)
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Setup required packages'
+        run:
+          sudo apt-get install -y ninja-build libboost-all-dev libxxhash-dev
+          libfmt-dev
+
+      - name: 'Setup clang'
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 13
+
+      - name: 'Setup cmake'
+        run: cmake --version
+
+      - name: 'Update git submodules'
+        run: |
+          git submodule sync
+          git submodule update --init --recursive
+
+      - name: 'Run test'
+        run: |
+          export C=/usr/local/bin/clang
+          export CXX=/usr/local/bin/clang++
+          mkdir -p build.debug && cd build.debug
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
+          ninja memory_test
+          test/memory_test

--- a/.github/workflows/test-linux-gcc.yml
+++ b/.github/workflows/test-linux-gcc.yml
@@ -1,0 +1,39 @@
+name: Linux (gcc)
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Setup required packages'
+        run:
+          sudo apt-get install -y ninja-build libboost-all-dev libxxhash-dev
+          libfmt-dev
+
+      - name: 'Setup gcc'
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 11
+
+      - name: 'Setup cmake'
+        run: cmake --version
+
+      - name: 'Update git submodules'
+        run: |
+          git submodule sync
+          git submodule update --init --recursive
+
+      - name: 'Run test'
+        run: |
+          export C=/usr/local/bin/gcc
+          export CXX=/usr/local/bin/g++
+          mkdir -p build.debug && cd build.debug
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
+          ninja memory_test
+          test/memory_test

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.app
 
 cmake-*
-build-*
+build*/
 compile_commands.json
 .ccls-cache/
 .cache/

--- a/arena/metrics.hpp
+++ b/arena/metrics.hpp
@@ -20,11 +20,11 @@
 
 #pragma once
 
-#include <bits/chrono.h>  // for operator""ms, duration, stea...
-#include <fmt/core.h>     // for format
+#include <fmt/core.h>  // for format
 
 #include <array>          // for array, array<>::value_type
 #include <atomic>         // for atomic, memory_order, memory...
+#include <chrono>         // for operator""ms, duration, stea...
 #include <compare>        // for operator<=, strong_ordering
 #include <cstdint>        // for uint64_t, uint32_t
 #include <memory>         // for allocator, unique_ptr

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -1,13 +1,12 @@
 #include "string.hpp"
-#include "arena_string.hpp"
 
-#include <bits/chrono.h>  // for duration, system_clock, system_clock::t...
-#include <cxxabi.h>       // for __forced_unwind
-#include <fmt/core.h>     // for format
-#include <sys/types.h>    // for uint
+#include <cxxabi.h>     // for __forced_unwind
+#include <fmt/core.h>   // for format
+#include <sys/types.h>  // for uint
 
 #include <algorithm>    // for for_each
 #include <atomic>       // for atomic, __atomic_base
+#include <chrono>       // for duration, system_clock, system_clock::t...
 #include <cstddef>      // for size_t
 #include <iostream>     // for cout
 #include <iterator>     // for move_iterator, make_move_iterator, oper...
@@ -17,7 +16,8 @@
 #include <type_traits>  // for is_same
 #include <vector>       // for vector
 
-#include "arena/arena.hpp"    // for size_t, Arena, Arena::Options
+#include "arena/arena.hpp"  // for size_t, Arena, Arena::Options
+#include "arena_string.hpp"
 #include "doctest/doctest.h"  // for binary_assert, CHECK_EQ, TestCase, CHECK
 
 namespace stdb::memory {
@@ -116,8 +116,8 @@ template <class String>
 void arena_clause11_21_4_2_d(String& test) {
     // Copy constructor with position and length
     const size_t pos = random(0, test.size());
-    String s(test, pos,
-             random(0, 9) ? random(0, test.size() - pos) : String::npos, test.get_allocator());  // test for npos, too, in 10% of the cases
+    String s(test, pos, random(0, 9) ? random(0, test.size() - pos) : String::npos,
+             test.get_allocator());  // test for npos, too, in 10% of the cases
     test = s;
 }
 
@@ -2571,11 +2571,11 @@ TEST_CASE("string::Clone") {
 TEST_CASE("arena_string::normal") {
     Arena arena(Arena::Options::GetDefaultOptions());
     SUBCASE("Create") {
-        auto * str = arena.Create<arena_string>();
+        auto* str = arena.Create<arena_string>();
         CHECK_EQ(*str, "");
         CHECK_EQ(arena.check(reinterpret_cast<const char*>(str)), ArenaContainStatus::BlockUsed);
         CHECK_EQ(arena.check(str->data()), ArenaContainStatus::BlockUsed);
-        auto * str1 = arena.Create<arena_string>("1234567");
+        auto* str1 = arena.Create<arena_string>("1234567");
         CHECK_EQ(*str1, "1234567");
         CHECK_EQ(arena.check(reinterpret_cast<const char*>(str1)), ArenaContainStatus::BlockUsed);
         CHECK_EQ(arena.check(str1->data()), ArenaContainStatus::BlockUsed);
@@ -2688,11 +2688,11 @@ TEST_CASE("arena_string::Clone") {
 TEST_CASE("arena_string::normal") {
     Arena arena(Arena::Options::GetDefaultOptions());
     SUBCASE("Create") {
-        auto * str = arena.Create<arena_string>();
+        auto* str = arena.Create<arena_string>();
         CHECK_EQ(*str, "");
         CHECK_EQ(arena.check(reinterpret_cast<const char*>(str)), ArenaContainStatus::BlockUsed);
         CHECK_EQ(arena.check(str->data()), ArenaContainStatus::BlockUsed);
-        auto * str1 = arena.Create<arena_string>("1234567");
+        auto* str1 = arena.Create<arena_string>("1234567");
         CHECK_EQ(*str1, "1234567");
         CHECK_EQ(arena.check(reinterpret_cast<const char*>(str1)), ArenaContainStatus::BlockUsed);
         CHECK_EQ(arena.check(str1->data()), ArenaContainStatus::BlockUsed);
@@ -2758,7 +2758,7 @@ TEST_CASE("arena_string::testAllClauses") {
 
 #define TEST_CLAUSE_ARENA(x) l(#x, arena_clause11_##x<std::string>, arena_clause11_##x<arena_string>);
 
-//    TEST_CLAUSE_ARENA(21_4_2_a);
+    //    TEST_CLAUSE_ARENA(21_4_2_a);
     TEST_CLAUSE_ARENA(21_4_2_b);
     TEST_CLAUSE_ARENA(21_4_2_c);
     TEST_CLAUSE_ARENA(21_4_2_d);
@@ -2848,6 +2848,5 @@ TEST_CASE("arena_string::testAllClauses") {
     TEST_CLAUSE_ARENA(21_4_8_1_l);
     TEST_CLAUSE_ARENA(21_4_8_9_a);
 }
-
 
 }  // namespace stdb::memory


### PR DESCRIPTION
`<bits/chrono.h>` is not part of the C++ standard and is, therefore, non-portable, and should be avoided