### PR TITLE
replace <bits/chrono.h> with <chrono>

### DIFF
--- a/arena/metrics.hpp
+++ b/arena/metrics.hpp
@@ -20,11 +20,11 @@
 
 #pragma once
 
-#include <bits/chrono.h>  // for operator""ms, duration, stea...
 #include <fmt/core.h>     // for format
 
 #include <array>          // for array, array<>::value_type
 #include <atomic>         // for atomic, memory_order, memory...
+#include <chrono>         // for operator""ms, duration, stea...
 #include <compare>        // for operator<=, strong_ordering
 #include <cstdint>        // for uint64_t, uint32_t
 #include <memory>         // for allocator, unique_ptr

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -1,13 +1,13 @@
 #include "string.hpp"
 #include "arena_string.hpp"
 
-#include <bits/chrono.h>  // for duration, system_clock, system_clock::t...
 #include <cxxabi.h>       // for __forced_unwind
 #include <fmt/core.h>     // for format
 #include <sys/types.h>    // for uint
 
 #include <algorithm>    // for for_each
 #include <atomic>       // for atomic, __atomic_base
+#include <chrono>       // for duration, system_clock, system_clock::t...
 #include <cstddef>      // for size_t
 #include <iostream>     // for cout
 #include <iterator>     // for move_iterator, make_move_iterator, oper...


### PR DESCRIPTION
<bits/chrono.h> is not part of the C++ standard and is, therefore, non-portable, and should be avoided.

this PR will fix issues arised during `FBE` ci.