### PR TITLE
add arena_vector to replace pmr::vector

### DIFF
--- a/arena/arena.cc
+++ b/arena/arena.cc
@@ -150,4 +150,12 @@ auto Arena::check(const char* ptr) -> ArenaContainStatus {
     return ArenaContainStatus::NotContain;
 }
 
+auto Arena::extend(const char* ptr, uint64_t size, uint64_t space_to_extend) -> bool {
+    if (auto* block = _last_block; (block != nullptr) && (block->Pos() == ptr + size) && (block->remain() > space_to_extend)) {
+        block->alloc(space_to_extend);
+        return true;
+    }
+    return false;
+}
+
 }  // namespace stdb::memory

--- a/arena/arena.hpp
+++ b/arena/arena.hpp
@@ -112,6 +112,7 @@ enum class ArenaContainStatus : uint8_t
     BlockUsed,
     BlockUnUsed,
 };
+
 /*
  * Arena is a session-ware allocator implementation,
  * it can be used to allocate memory blocks and de-allocate them in a single call.
@@ -481,6 +482,8 @@ class Arena
      */
     auto check(const char* ptr) -> ArenaContainStatus;
 
+    auto extend(const char* ptr, uint64_t size, uint64_t space_to_extend) -> bool;
+
     /*
      * get all cleanup nodes, just for testing.
      */
@@ -651,5 +654,6 @@ class Arena
 
 // the size of the Block's header.
 static constexpr uint64_t kBlockHeaderSize = AlignUpTo<kByteSize>(sizeof(memory::Arena::Block));
+
 
 }  // namespace stdb::memory

--- a/arena/arenahelper.hpp
+++ b/arena/arenahelper.hpp
@@ -43,6 +43,13 @@ namespace pmr = ::std::experimental::pmr;
 
 // NOLINTEND
 
+
+template <typename , typename = void>
+constexpr bool is_arena_memory_resource_v = false;
+
+template <typename T>
+constexpr bool is_arena_memory_resource_v<T, std::void_t<decltype(std::declval<T>().get_arena()) >> = true;
+
 namespace stdb::memory {
 /*
  * class ArenaHelper is for helping the Type stored in the Arena memory.

--- a/container/stdb_vector.hpp
+++ b/container/stdb_vector.hpp
@@ -494,8 +494,8 @@ class core
  * stdb_vector is a vector-like container that uses a variadic size buffer to store elements.
  * it is designed to be used in the non-arena memory.
  */
-template <typename T>
-class stdb_vector : public core<T>
+template <typename T, template <typename > typename Core = core>
+class stdb_vector : public Core<T>
 {
    public:
     using size_type = std::size_t;

--- a/container/stdb_vector.hpp
+++ b/container/stdb_vector.hpp
@@ -1612,6 +1612,12 @@ auto operator<=>(const stdb_vector<T>& lhs, const stdb_vector<T>& rhs) -> std::s
     return std::strong_ordering::equal;
 }
 
+template <typename T>
+using vector = stdb_vector<T, core>;
+
+template <typename T>
+using arena_vector = stdb_vector<T, arena_core>;
+
 }  // namespace stdb::container
 
 namespace std {

--- a/container/stdb_vector.hpp
+++ b/container/stdb_vector.hpp
@@ -78,7 +78,7 @@ template <typename T>
 [[gnu::always_inline]] inline void construct_range(T* __restrict__ first, T* __restrict__ last) {
     assert(first != nullptr and last != nullptr);
     assert(first < last);
-    if constexpr (IsRelocatable<T>) {
+    if constexpr (IsZeroInitable<T>) {
         // set zero to all bytes.
         std::memset(first, 0, static_cast<size_t>(last - first) * sizeof(T));
     } else {

--- a/test/arena_test.cc
+++ b/test/arena_test.cc
@@ -1243,4 +1243,14 @@ TEST_CASE("Arena-memory::struct_with_string") {
     ptr->name.append("agadsgavb123421341234lk1234jl231jk4lkjasdlkfjasdlkfjalskfj");
 }
 
+TEST_CASE("Arena-memory::get_arena_traits") {
+    auto options = Arena::Options::GetDefaultOptions();
+    Arena a(options);
+    auto rs = a.get_memory_resource();
+    CHECK_EQ(is_arena_memory_resource_v<decltype(*rs)>, true);
+    std::pmr::memory_resource* mr = a.get_memory_resource();
+
+    CHECK_EQ(is_arena_memory_resource_v<decltype(*mr)>, true);
+}
+
 }  // namespace stdb::memory


### PR DESCRIPTION
arena_vector is better than pmr::vector,
if the arena_vector is the last object in arena block, and the block still has space to extend, use it.

