### PR TITLE
add benchmark for stack-like using stdb_vector, and confirm that

### DIFF
--- a/benchmark/vector_bench.cc
+++ b/benchmark/vector_bench.cc
@@ -862,8 +862,8 @@ static void reserve_std_vector(benchmark::State& state) {
     std::vector<T> vec;
     for (auto _ : state) {
         vec.reserve(times * 2);
-        benchmark::DoNotOptimize(vec);
     }
+    vec.push_back(T());
 }
 
 template <typename T>
@@ -871,8 +871,8 @@ static void reserve_stdb_vector(benchmark::State& state) {
     stdb::container::stdb_vector<T> vec;
     for (auto _ : state) {
         vec.reserve(times * 2);
-        benchmark::DoNotOptimize(vec);
     }
+    vec.push_back(T());
 }
 template <typename T>
 auto generate_t() -> T {
@@ -902,25 +902,6 @@ static void stack_like_std_vector(benchmark::State& state) {
 }
 
 template <typename T>
-static void stack_like_std_vector_with_size(benchmark::State& state) {
-    std::vector<T> vec;
-    vec.reserve(16);
-    for (auto _ : state) {
-        vec.push_back(T{});
-        if (vec.back() == T{}) {
-            vec.pop_back();
-        }
-        for (uint64_t i = 0; i < 8; ++i) {
-            vec.push_back(generate_t<T>());
-        }
-        auto size = vec.size();
-        for (size_t  i = 0; i < size; ++i) {
-            vec.pop_back();
-        }
-    }
-}
-
-template <typename T>
 static void stack_like_stdb_vector(benchmark::State& state) {
     stdb_vector<T> vec;
     vec.reserve(16);
@@ -939,10 +920,12 @@ static void stack_like_stdb_vector(benchmark::State& state) {
 }
 
 template <typename T>
-static void stack_like_stdb_vector_with_size(benchmark::State& state) {
-    stdb_vector<T> vec;
-    vec.reserve(16);
+static void stack_like_std_vector_with_size(benchmark::State& state) {
+
     for (auto _ : state) {
+        std::vector<T> vec;
+        vec.reserve(16);
+
         vec.push_back(T{});
         if (vec.back() == T{}) {
             vec.pop_back();
@@ -955,6 +938,29 @@ static void stack_like_stdb_vector_with_size(benchmark::State& state) {
             vec.pop_back();
         }
     }
+
+}
+
+template <typename T>
+static void stack_like_stdb_vector_with_size(benchmark::State& state) {
+
+    for (auto _ : state) {
+        stdb_vector<T> vec;
+        vec.reserve(16);
+
+        vec.push_back(T{});
+        if (vec.back() == T{}) {
+            vec.pop_back();
+        }
+        for (uint64_t i = 0; i < 8; ++i) {
+            vec.push_back(generate_t<T>());
+        }
+        auto size = vec.size();
+        for (size_t  i = 0; i < size; ++i) {
+            vec.pop_back();
+        }
+    }
+
 }
 
 BENCHMARK(init_std_vector);

--- a/benchmark/vector_bench.cc
+++ b/benchmark/vector_bench.cc
@@ -874,6 +874,63 @@ static void reserve_stdb_vector(benchmark::State& state) {
         benchmark::DoNotOptimize(vec);
     }
 }
+template <typename T>
+auto generate_t() -> T {
+    if constexpr(std::is_pointer_v<T>) {
+        return T(-1);
+    } else {
+        return T{1};
+    }
+}
+
+template<typename T>
+void std_stack_like_operator(std::vector<T>& vec) {
+    vec.push_back(T{});
+    if (vec.back() == T{}) {
+        vec.pop_back();
+    }
+    for (uint64_t i = 0; i < 8; ++i) {
+        vec.push_back(generate_t<T>());
+    }
+    if (not vec.empty()) {
+        vec.pop_back();
+    }
+
+}
+
+template<typename T>
+void stdb_stack_like_operator(stdb_vector<T>& vec) {
+    vec.push_back(T{});
+    if (vec.back() == T{}) {
+        vec.pop_back();
+    }
+    for (uint64_t i = 0; i < 8; ++i) {
+        vec.push_back(generate_t<T>());
+    }
+    if (not vec.empty()) {
+        vec.pop_back();
+    }
+
+}
+
+
+template <typename T>
+static void stack_like_std_vector(benchmark::State& state) {
+    std::vector<T> vec;
+    vec.reserve(16);
+    for (auto _ : state) {
+        std_stack_like_operator(vec);
+    }
+}
+
+template <typename T>
+static void stack_like_stdb_vector(benchmark::State& state) {
+    stdb_vector<T> vec;
+    vec.reserve(16);
+    for (auto _ : state) {
+        stdb_stack_like_operator(vec);
+    }
+}
 
 BENCHMARK(init_std_vector);
 BENCHMARK(init_stdb_vector_with_pushback_unsafe);
@@ -888,6 +945,10 @@ BENCHMARK(reserve_std_vector<trivially_copyable>);
 BENCHMARK(reserve_std_vector<non_trivially_copyable>);
 BENCHMARK(reserve_stdb_vector<trivially_copyable>);
 BENCHMARK(reserve_stdb_vector<non_trivially_copyable>);
+
+BENCHMARK(stack_like_std_vector<char*>);
+BENCHMARK(stack_like_stdb_vector<char*>);
+
 BENCHMARK_MAIN();
 
 // NOLINTEND

--- a/benchmark/vector_bench.cc
+++ b/benchmark/vector_bench.cc
@@ -859,7 +859,7 @@ static_assert(!IsRelocatable<non_trivially_copyable>, "non_trivially_copyable is
 
 template <typename T>
 static void reserve_std_vector(benchmark::State& state) {
-    std::vector<T> vec(times);
+    std::vector<T> vec;
     for (auto _ : state) {
         vec.reserve(times * 2);
         benchmark::DoNotOptimize(vec);
@@ -868,7 +868,7 @@ static void reserve_std_vector(benchmark::State& state) {
 
 template <typename T>
 static void reserve_stdb_vector(benchmark::State& state) {
-    stdb::container::stdb_vector<T> vec(times);
+    stdb::container::stdb_vector<T> vec;
     for (auto _ : state) {
         vec.reserve(times * 2);
         benchmark::DoNotOptimize(vec);
@@ -883,43 +883,40 @@ auto generate_t() -> T {
     }
 }
 
-template<typename T>
-void std_stack_like_operator(std::vector<T>& vec) {
-    vec.push_back(T{});
-    if (vec.back() == T{}) {
-        vec.pop_back();
-    }
-    for (uint64_t i = 0; i < 8; ++i) {
-        vec.push_back(generate_t<T>());
-    }
-    while (not vec.empty()) {
-        vec.pop_back();
-    }
-
-}
-
-template<typename T>
-void stdb_stack_like_operator(stdb_vector<T>& vec) {
-    vec.push_back(T{});
-    if (vec.back() == T{}) {
-        vec.pop_back();
-    }
-    for (uint64_t i = 0; i < 8; ++i) {
-        vec.push_back(generate_t<T>());
-    }
-    while (not vec.empty()) {
-        vec.pop_back();
-    }
-
-}
-
-
 template <typename T>
 static void stack_like_std_vector(benchmark::State& state) {
     std::vector<T> vec;
     vec.reserve(16);
     for (auto _ : state) {
-        std_stack_like_operator(vec);
+        vec.push_back(T{});
+        if (vec.back() == T{}) {
+            vec.pop_back();
+        }
+        for (uint64_t i = 0; i < 8; ++i) {
+            vec.push_back(generate_t<T>());
+        }
+        while (not vec.empty()) {
+            vec.pop_back();
+        }
+    }
+}
+
+template <typename T>
+static void stack_like_std_vector_with_size(benchmark::State& state) {
+    std::vector<T> vec;
+    vec.reserve(16);
+    for (auto _ : state) {
+        vec.push_back(T{});
+        if (vec.back() == T{}) {
+            vec.pop_back();
+        }
+        for (uint64_t i = 0; i < 8; ++i) {
+            vec.push_back(generate_t<T>());
+        }
+        auto size = vec.size();
+        for (size_t  i = 0; i < size; ++i) {
+            vec.pop_back();
+        }
     }
 }
 
@@ -928,7 +925,35 @@ static void stack_like_stdb_vector(benchmark::State& state) {
     stdb_vector<T> vec;
     vec.reserve(16);
     for (auto _ : state) {
-        stdb_stack_like_operator(vec);
+        vec.push_back(T{});
+        if (vec.back() == T{}) {
+            vec.pop_back();
+        }
+        for (uint64_t i = 0; i < 8; ++i) {
+            vec.push_back(generate_t<T>());
+        }
+        while (not vec.empty()) {
+            vec.pop_back();
+        }
+    }
+}
+
+template <typename T>
+static void stack_like_stdb_vector_with_size(benchmark::State& state) {
+    stdb_vector<T> vec;
+    vec.reserve(16);
+    for (auto _ : state) {
+        vec.push_back(T{});
+        if (vec.back() == T{}) {
+            vec.pop_back();
+        }
+        for (uint64_t i = 0; i < 8; ++i) {
+            vec.push_back(generate_t<T>());
+        }
+        auto size = vec.size();
+        for (size_t  i = 0; i < size; ++i) {
+            vec.pop_back();
+        }
     }
 }
 
@@ -948,6 +973,8 @@ BENCHMARK(reserve_stdb_vector<non_trivially_copyable>);
 
 BENCHMARK(stack_like_std_vector<char*>);
 BENCHMARK(stack_like_stdb_vector<char*>);
+BENCHMARK(stack_like_std_vector_with_size<char*>);
+BENCHMARK(stack_like_stdb_vector_with_size<char*>);
 
 BENCHMARK_MAIN();
 

--- a/benchmark/vector_bench.cc
+++ b/benchmark/vector_bench.cc
@@ -892,7 +892,7 @@ void std_stack_like_operator(std::vector<T>& vec) {
     for (uint64_t i = 0; i < 8; ++i) {
         vec.push_back(generate_t<T>());
     }
-    if (not vec.empty()) {
+    while (not vec.empty()) {
         vec.pop_back();
     }
 
@@ -907,7 +907,7 @@ void stdb_stack_like_operator(stdb_vector<T>& vec) {
     for (uint64_t i = 0; i < 8; ++i) {
         vec.push_back(generate_t<T>());
     }
-    if (not vec.empty()) {
+    while (not vec.empty()) {
         vec.pop_back();
     }
 

--- a/container/stdb_vector.hpp
+++ b/container/stdb_vector.hpp
@@ -1131,7 +1131,7 @@ class stdb_vector : public core<T>
         }
     }
 
-    [[gnu::always_inline]] inline void pop_back() { destroy_ptr(this->_finish-- - 1); }
+    [[gnu::always_inline]] inline void pop_back() { destroy_ptr(--this->_finish); }
 
     template <Safety safety = Safety::Safe>
     constexpr void resize(size_type count) {

--- a/container/stdb_vector.hpp
+++ b/container/stdb_vector.hpp
@@ -1131,7 +1131,7 @@ class stdb_vector : public core<T>
         }
     }
 
-    [[gnu::always_inline]] inline void pop_back() { destroy_ptr(--this->_finish); }
+    constexpr void pop_back() noexcept { destroy_ptr(--this->_finish); }
 
     template <Safety safety = Safety::Safe>
     constexpr void resize(size_type count) {

--- a/container/stdb_vector.hpp
+++ b/container/stdb_vector.hpp
@@ -382,26 +382,26 @@ class core
         _edge = std::exchange(rhs._edge, _edge);
     }
 
-    [[nodiscard, gnu::always_inline]] constexpr auto size() const -> size_type {
+    [[nodiscard, gnu::always_inline]] constexpr auto size() const noexcept -> size_type {
         Assert(_finish >= _start);
-        return static_cast<size_type>(_finish - _start);
+        return (size_type)(_finish - _start);
     }
 
-    [[nodiscard, gnu::always_inline]] constexpr auto capacity() const -> size_type {
+    [[nodiscard, gnu::always_inline]] constexpr auto capacity() const noexcept -> size_type {
         Assert(_edge >= _start);
-        return static_cast<size_type>(_edge - _start);
+        return (size_type)(_edge - _start);
     }
 
-    [[nodiscard, gnu::always_inline]] auto full() const -> bool {
+    [[nodiscard, gnu::always_inline]] auto full() const noexcept -> bool {
         Assert(_finish <= _edge);
         return _edge == _finish;
     }
     // data access section
-    [[nodiscard, gnu::always_inline]] auto at(size_type index) const -> const_reference {
+    [[nodiscard, gnu::always_inline]] auto at(size_type index) const noexcept -> const_reference {
         Assert(index < size());
         return _start[index];  // NOLINT
     }
-    [[nodiscard, gnu::always_inline]] auto at(size_type index) -> reference {
+    [[nodiscard, gnu::always_inline]] auto at(size_type index) noexcept -> reference {
         Assert(index < size());
         return _start[index];  // NOLINT
     }
@@ -450,7 +450,7 @@ class core
         destroy_range(_start, _finish);
     }
 
-    [[gnu::always_inline, nodiscard]] auto max_size() const -> size_type { return kFastVectorMaxSize / sizeof(T); }
+    [[gnu::always_inline, nodiscard]] auto max_size() const noexcept -> size_type { return kFastVectorMaxSize / sizeof(T); }
 
     // move [src, end()) to dst start range from front to end
     [[gnu::always_inline]] void move_forward(T* __restrict__ dst, T* __restrict__ src) {


### PR DESCRIPTION
stdb_vector is slower than std:vector in this scenario.

> 
> stack_like_std_vector<char*>                      61.1 ns         60.8 ns     10000000
> stack_like_stdb_vector<char*>                     68.9 ns         68.6 ns      9672694