### PR TITLE
[optparse] make optparse support more than one char 's short arg

### DIFF
--- a/optparse/optparse.cc
+++ b/optparse/optparse.cc
@@ -39,6 +39,15 @@
 
 namespace stdb::optparse {
 
+auto trim_string(string input) -> string {
+    size_t end_pos = input.find_last_not_of(" \t\n\r\f\v");
+    size_t start_pos = input.find_first_not_of(" \t\n\r\f\v");
+    if (end_pos == string::npos or start_pos == string::npos) {
+        return "";
+    }
+    return input.substr(start_pos, end_pos - start_pos + 1);
+}
+
 auto Option::validate() -> bool {
     // if _dest is empty, we will use the first long option name as the _dest.
     if (_dest.empty()) {
@@ -193,13 +202,13 @@ auto OptionParser::parse_args(vector<stdb::optparse::string> args) -> ValueStore
         auto front = args_list.peek();
         auto arg_type = extract_arg_type(front);
         if (arg_type == OptionType::InvalidOpt) {
-            // do nothing if the first argument is not an option.
-            _invalid_args.emplace_back(std::move(front));
-            continue;
-        }
-        if (arg_type == OptionType::ShortOpt) {
+            // pop the first argument is not an option, and drag-and-drop to the invalid args list.
+            auto the_invalid_arg = args_list.pop();
+            _invalid_args.emplace_back(std::move(the_invalid_arg));
+        } else if (arg_type == OptionType::ShortOpt) {
             handle_short_opt(store, args_list);
-        } else if (arg_type == OptionType::LongOpt) {
+        } else {
+            // arg_type == OptionType::LongOpt
             handle_long_opt(store, args_list);
         }
     }
@@ -378,6 +387,7 @@ auto OptionParser::handle_short_opt(ValueStore& values, ArgList& args) -> bool {
             exit(0);
         }
         auto short_name = extract_short_opt_name(front);
+        short_name = trim_string(short_name);
 
         // lookup the option of short options.
         auto opt_it = _short_option_map.find(short_name);
@@ -438,6 +448,9 @@ auto OptionParser::handle_long_opt(stdb::optparse::ValueStore& values, ArgList& 
             exit(0);
         }
         auto long_name = extract_long_opt_name(front);
+
+        long_name = trim_string(long_name);
+
         auto opt_it = _long_option_map.find(long_name);
         if (opt_it == _long_option_map.end()) {
             _invalid_args.emplace_back(std::move(front));
@@ -564,5 +577,9 @@ auto OptionParser::print_help() -> void { fmt::print("{}", format_help()); }
 auto OptionParser::print_usage() -> void { fmt::print("{}", format_usage()); }
 
 auto OptionParser::print_version() -> void { fmt::print("{}", format_verison()); }
+
+auto OptionParser::invalid_args() -> vector<string> {
+    return std::move(_invalid_args);
+}
 
 }  // namespace stdb::optparse

--- a/optparse/optparse.cc
+++ b/optparse/optparse.cc
@@ -69,12 +69,14 @@ OptionParser::OptionParser(char prefix, stdb::optparse::ConflictHandler handler)
     : _prefix{prefix}, _conflict_handler{handler} {}
 
 auto OptionParser::extract_option_type(const string& opt) const -> OptionType {
-    if (opt.size() == 2 and opt[0] == _prefix) {
-        return OptionType::ShortOpt;
-    }
     if (opt.size() > 2 and opt.substr(0, 2) == _long_prefix) {
         return OptionType::LongOpt;
     }
+
+    if (opt[0] == _prefix) {
+        return OptionType::ShortOpt;
+    }
+
     return OptionType::InvalidOpt;
 }
 
@@ -336,19 +338,16 @@ auto OptionParser::process_opt(const stdb::optparse::Option& opt, stdb::optparse
     return false;
 }
 
-auto extract_short_opt_name(string opt) -> string { return opt.substr(0, 2); }
-
-auto extract_short_opt_value(string opt) -> string {
-    if (opt.size() == 2) return {};
-    return opt.find('=') == string::npos ? opt.substr(2) : opt.substr(3);
-}
-
 auto extract_long_opt_name(string opt) -> string {
     auto delim = opt.find('=');
     if (delim == string::npos) {
         return opt;
     }
     return opt.substr(0, delim);
+}
+
+auto extract_short_opt_name(string opt) -> string { /*return opt.substr(0, 2);*/
+    return extract_long_opt_name(opt);
 }
 
 auto extract_long_opt_value(string opt) -> string {
@@ -359,10 +358,20 @@ auto extract_long_opt_value(string opt) -> string {
     return opt.substr(delim + 1);
 }
 
+auto extract_short_opt_value(string opt) -> string {
+    /*
+    if (opt.size() == 2) return {};
+    return opt.find('=') == string::npos ? opt.substr(2) : opt.substr(3);
+     */
+    return extract_long_opt_value(opt);
+}
+
+
 auto OptionParser::handle_short_opt(ValueStore& values, ArgList& args) -> bool {
     if (not args.empty()) {
         // get front of args
         auto front = args.pop();
+        // we do not use other prefix except '-' for short options.
         if (front == "-h") {
             // if the front is -h, then print help message and exit.
             print_help();

--- a/optparse/optparse.hpp
+++ b/optparse/optparse.hpp
@@ -362,6 +362,13 @@ class OptionParser
     auto print_usage() -> void;
     auto format_verison() -> string;
     auto print_version() -> void;
+
+    /**
+     * @brief move the invalid args vector out of the Object.
+     *
+     * @return the moved invalid args vector.
+     */
+    auto invalid_args() -> vector<string>;
 };
 
 }  // namespace stdb::optparse

--- a/test/optparse_test.cc
+++ b/test/optparse_test.cc
@@ -73,6 +73,12 @@ TEST_CASE("optparser::smoke") {
     CHECK_EQ(options2.get<bool>("verbose"), false);
     CHECK_EQ(options2.get<string>("config"), "config.txt");
     CHECK_EQ(options2.get<int>("size"), 100);
+
+    auto option3 = parser.parse_args({"-f", "test.txt", "-q", "-cconfig.txt", "-sz", "100", "-v"});
+    auto invalid_args = parser.invalid_args();
+    CHECK_EQ(invalid_args.size(), 1);
+    CHECK_EQ(invalid_args[0], "-cconfig.txt");
+
 }
 
 TEST_CASE("optparser::choice") {
@@ -139,12 +145,22 @@ TEST_CASE("optparser::complex") {
     fmt::print("------------\n");
     fmt::print("{}", parser.format_help());
 
-    auto options2 = parser.parse_args({"-f=test.txt", "--duration=2.0", "-r1", "100"});
+    auto options2 = parser.parse_args({"-f=test.txt", "--duration=2.0", "-r =1", "100"});
     // the bool type always has a default value
     CHECK_EQ(options2.get<bool>("quiet"), false);
     CHECK_EQ(options2.get<bool>("help"), std::nullopt);
     // the string type need to check if it has a value
     CHECK_EQ(options2.get<string>("config").has_value(), false);
+    auto ratios = options2.get_list("ratio");
+
+    CHECK_EQ(ratios->size(), 2);
+    auto ratio1 = std::get<int>(ratios->at(0));
+    auto ratio2 = std::get<int>(ratios->at(1));
+
+    CHECK_EQ(ratio1, 1);
+    CHECK_EQ(ratio2, 100);
+
 }
+
 
 }  // namespace stdb::optparse

--- a/test/optparse_test.cc
+++ b/test/optparse_test.cc
@@ -54,21 +54,21 @@ TEST_CASE("optparser::smoke") {
       .default_value("false")
       .help("print status messages to stdout");
     parser.add_option("-c", "--config").dest("config").action(Action::Store).nargs(1).help("config file");
-    parser.add_option("-s", "--size")
+    parser.add_option("-sz", "--size")
       .type(Type::Int)
       .action(Action::Store)
       .dest("size")
       .nargs(1)
       .help("size of the data");
 
-    auto options = parser.parse_args({"-f", "test.txt", "-q", "-c", "config.txt", "-s", "100"});
+    auto options = parser.parse_args({"-f", "test.txt", "-q", "-c", "config.txt", "-sz", "100"});
 
     CHECK_EQ(options.get<string>("filename"), "test.txt");
     CHECK_EQ(options.get<bool>("verbose"), false);
     CHECK_EQ(options.get<string>("config"), "config.txt");
     CHECK_EQ(options.get<int>("size"), 100);
 
-    auto options2 = parser.parse_args({"-f=test.txt", "-q", "-cconfig.txt", "--size=100"});
+    auto options2 = parser.parse_args({"-f=test.txt", "-q", "-c=config.txt", "--size=100"});
     CHECK_EQ(options2.get<string>("filename"), "test.txt");
     CHECK_EQ(options2.get<bool>("verbose"), false);
     CHECK_EQ(options2.get<string>("config"), "config.txt");
@@ -118,7 +118,7 @@ TEST_CASE("optparser::complex") {
         "print duration time for the loooooooooooooooooooooong running!! lasting lasting lasting for testing testing");
     parser.add_option("-t", "--test").type(Type::Bool).action(Action::Store).nargs(0).help("test");
 
-    auto options = parser.parse_args({"-f", "test.txt", "-q", "-c", "config.txt", "--duration=2.0", "-r1", "100"});
+    auto options = parser.parse_args({"-f", "test.txt", "-q", "-c", "config.txt", "--duration=2.0", "-r=1", "100"});
 
     CHECK_EQ(options.get<string>("filename"), "test.txt");
     CHECK_EQ(options.get<bool>("verbose"), false);


### PR DESCRIPTION
make the short arg support more than 1 char 's short args, such as -ltc.

BTW. and support -r = 1, the optparse will trim space or other unvisible char.
but -c1 will be not supported in future.