### PR TITLE
[Optparse] support comma split values

### DIFF
--- a/optparse/optparse.cc
+++ b/optparse/optparse.cc
@@ -353,7 +353,7 @@ auto OptionParser::process_opt(const stdb::optparse::Option& opt, stdb::optparse
     return false;
 }
 
-auto extract_long_opt_name(string opt) -> string {
+auto extract_opt_name(string opt) -> string {
     auto delim = opt.find('=');
     if (delim == string::npos) {
         return opt;
@@ -361,11 +361,7 @@ auto extract_long_opt_name(string opt) -> string {
     return opt.substr(0, delim);
 }
 
-auto extract_short_opt_name(string opt) -> string { /*return opt.substr(0, 2);*/
-    return extract_long_opt_name(opt);
-}
-
-auto extract_long_opt_value(string opt) -> string {
+auto extract_opt_value(string opt) -> string {
     auto delim = opt.find('=');
     if (delim == string::npos) {
         return {};
@@ -387,7 +383,7 @@ auto OptionParser::handle_short_opt(ValueStore& values, ArgList& args) -> bool {
         // get front of args
         auto front = args.pop();
 
-        auto short_name = extract_short_opt_name(front);
+        auto short_name = extract_opt_name(front);
         short_name = trim_string(short_name);
 
         // lookup the option of short options.
@@ -407,7 +403,7 @@ auto OptionParser::handle_short_opt(ValueStore& values, ArgList& args) -> bool {
         }
         // if nargs is 1, then process the option and pop the next 1 argument.
         if (opt.nargs() == 1) {
-            if (auto val = extract_short_opt_value(front); val.empty()) {
+            if (auto val = extract_opt_value(front); val.empty()) {
                 // if the value is empty, then pop the next argument.
                 if (not args.empty()) {
                     auto next_val = args.pop();
@@ -421,7 +417,7 @@ auto OptionParser::handle_short_opt(ValueStore& values, ArgList& args) -> bool {
             return true;
         }
         auto nargs = opt.nargs();
-        if (auto val = extract_short_opt_value(front); not val.empty()) {
+        if (auto val = extract_opt_value(front); not val.empty()) {
             process_opt(opt, values, val);
             --nargs;
         }
@@ -445,7 +441,7 @@ auto OptionParser::handle_long_opt(stdb::optparse::ValueStore& values, ArgList& 
     if (not args.empty()) {
         auto front = args.pop();
 
-        auto long_name = extract_long_opt_name(front);
+        auto long_name = extract_opt_name(front);
 
         long_name = trim_string(long_name);
 
@@ -464,7 +460,7 @@ auto OptionParser::handle_long_opt(stdb::optparse::ValueStore& values, ArgList& 
         }
         // if nargs is 2, then process the option and pop the next 2 arguments.
         if (opt.nargs() == 1) {
-            if (auto val = extract_long_opt_value(front); val.empty()) {
+            if (auto val = extract_opt_value(front); val.empty()) {
                 // if the value is empty, then pop the next argument.
                 if (not args.empty()) {
                     auto next_val = args.pop();
@@ -480,7 +476,7 @@ auto OptionParser::handle_long_opt(stdb::optparse::ValueStore& values, ArgList& 
         // if nargs is greater than 2, then it is an invalid option.
 
         auto nargs = opt.nargs();
-        if (auto val = extract_long_opt_value(front); not val.empty()) {
+        if (auto val = extract_opt_value(front); not val.empty()) {
             process_opt(opt, values, val);
             --nargs;
         }

--- a/optparse/optparse.cc
+++ b/optparse/optparse.cc
@@ -369,12 +369,8 @@ auto extract_opt_value(string opt) -> string {
     return opt.substr(delim + 1);
 }
 
-auto extract_short_opt_value(string opt) -> string {
-    /*
-    if (opt.size() == 2) return {};
-    return opt.find('=') == string::npos ? opt.substr(2) : opt.substr(3);
-     */
-    return extract_long_opt_value(opt);
+auto OptionParser::has_value_to_process(string current_arg, const ArgList& args) const -> bool {
+    return current_arg.find('=') != string::npos or (not args.empty() and not args.peek().starts_with(_prefix));
 }
 
 

--- a/optparse/optparse.hpp
+++ b/optparse/optparse.hpp
@@ -381,6 +381,7 @@ class OptionParser
      * @return the moved invalid args vector.
      */
     auto invalid_args() -> vector<string>;
+    bool has_value_to_process(string current_arg, const ArgList& args) const;
 };
 
 }  // namespace stdb::optparse

--- a/optparse/optparse.hpp
+++ b/optparse/optparse.hpp
@@ -172,7 +172,6 @@ class Option
     Type _type = Type::String;
     string _dest = "";
     string _default = "";
-    size_t _nargs = 0;
     std::set<string> _choices{};
     string _help = "";
     string _env = "";
@@ -225,13 +224,6 @@ class Option
     }
 
     [[nodiscard]] inline auto default_value() const -> string { return _default; }
-
-    inline auto nargs(size_t n) -> Option& {
-        _nargs = n;
-        return *this;
-    }
-
-    [[nodiscard]] inline auto nargs() const -> size_t { return _nargs; }
 
     template <typename InputIterator>
     inline auto choices(InputIterator begin, InputIterator end) -> Option& {
@@ -315,6 +307,8 @@ class OptionParser
 
     auto add_option(Option option) -> Option&;
 
+    auto find_opt(string opt_name) -> Option*;
+
    public:
     explicit OptionParser(char prefix);
     OptionParser(char prefix, ConflictHandler handler);
@@ -359,8 +353,8 @@ class OptionParser
     auto add_help_option(string help_msg) -> void;
     auto add_version_option(string version_msg) -> void;
 
-    auto handle_short_opt(ValueStore&, ArgList& args) -> bool;
-    auto handle_long_opt(ValueStore&, ArgList& args) -> bool;
+    auto handle_opt(ValueStore&, ArgList& args) -> bool;
+//    auto handle_long_opt(ValueStore&, ArgList& args) -> bool;
 
     static auto process_opt(const Option&, ValueStore&, string) -> bool;
 

--- a/test/optparse_test.cc
+++ b/test/optparse_test.cc
@@ -38,11 +38,10 @@ namespace stdb::optparse {
 TEST_CASE("optparser::smoke") {
     auto parser = OptionParser();
     parser.program("test");
-    parser.add_option({"-f", "--file"}).dest("filename").action(Action::Store).nargs(1).help("write report to FILE");
+    parser.add_option({"-f", "--file"}).dest("filename").action(Action::Store).help("write report to FILE");
     parser.add_option("-q", "--quiet")
       .action(Action::StoreFalse)
       .type(Type::Bool)
-      .nargs(0)
       .dest("quiet")
       .default_value("true")
       .help("don't print status messages to stdout");
@@ -50,15 +49,13 @@ TEST_CASE("optparser::smoke") {
       .action(Action::StoreTrue)
       .dest("verbose")
       .type(Type::Bool)
-      .nargs(0)
       .default_value("false")
       .help("print status messages to stdout");
-    parser.add_option("-c", "--config").dest("config").action(Action::Store).nargs(1).help("config file");
+    parser.add_option("-c", "--config").dest("config").action(Action::Store).help("config file");
     parser.add_option("-sz", "--size")
       .type(Type::Int)
       .action(Action::Store)
       .dest("size")
-      .nargs(1)
       .help("size of the data");
 
     auto options = parser.parse_args({"-f", "test.txt", "-q", "-c", "config.txt", "-sz", "100"});
@@ -78,7 +75,23 @@ TEST_CASE("optparser::smoke") {
     auto invalid_args = parser.invalid_args();
     CHECK_EQ(invalid_args.size(), 1);
     CHECK_EQ(invalid_args[0], "-cconfig.txt");
+}
 
+TEST_CASE("optparser::comma_split") {
+    auto parser = OptionParser('-');
+    parser.add_option({"-f", "--file"}).dest("files").action(Action::Append).help("input files");
+    parser.add_option("-q", "--quiet")
+      .action(Action::StoreFalse)
+      .type(Type::Bool)
+      .dest("quiet")
+      .default_value("true")
+      .help("don't print status messages to stdout");
+
+    auto options = parser.parse_args({"-f=test.txt,  test2.txt", "-q"});
+    auto file_list = options.get_list<string>("files");
+    CHECK_EQ(file_list->size(), 2);
+    CHECK_EQ(file_list->at(0), "test.txt");
+    CHECK_EQ(file_list->at(1), "test2.txt");
 }
 
 TEST_CASE("optparser::choice") {
@@ -86,7 +99,6 @@ TEST_CASE("optparser::choice") {
     parser.add_option("-m", "--mode")
       .dest("mode")
       .action(Action::Store)
-      .nargs(1)
       .type(Type::Choice)
       .choices({"work", "wait", "silent"})
       .help("show modes");
@@ -99,11 +111,10 @@ TEST_CASE("optparser::choice") {
 TEST_CASE("optparser::complex") {
     auto parser = OptionParser();
     parser.program("test");
-    parser.add_option({"-f", "--file"}).dest("filename").action(Action::Store).nargs(1).help("write report to FILE");
+    parser.add_option({"-f", "--file"}).dest("filename").action(Action::Store).help("write report to FILE");
     parser.add_option("-q", "--quiet")
       .action(Action::StoreFalse)
       .type(Type::Bool)
-      .nargs(0)
       .dest("quiet")
       .default_value("true")
       .help("don't print status messages to stdout");
@@ -111,18 +122,16 @@ TEST_CASE("optparser::complex") {
       .action(Action::StoreTrue)
       .dest("verbose")
       .type(Type::Bool)
-      .nargs(0)
       .default_value(0)
       .help("print status messages to stdout");
-    parser.add_option("-c", "--config").dest("config").action(Action::Store).nargs(1).help("config file");
-    parser.add_option("-r", "--ratio").type(Type::Int).action(Action::Append).nargs(2).help("ratios");
+    parser.add_option("-c", "--config").dest("config").action(Action::Store).help("config file");
+    parser.add_option("-r", "--ratio").type(Type::Int).action(Action::Append).help("ratios");
     parser.add_option("--duration")
       .type(Type::Double)
       .action(Action::Store)
-      .nargs(1)
       .help(
         "print duration time for the loooooooooooooooooooooong running!! lasting lasting lasting for testing testing");
-    parser.add_option("-t", "--test").type(Type::Bool).action(Action::Store).nargs(0).help("test");
+    parser.add_option("-t", "--test").type(Type::Bool).action(Action::Store).help("test");
 
     auto options = parser.parse_args({"-f", "test.txt", "-q", "-c", "config.txt", "--duration=2.0", "-r=1", "100"});
 


### PR DESCRIPTION
1. remove nargs field.
2. make optparser support comma split values.
3. make handle_opt has same behaviours for long and short opt.