### PR TITLE
make invalid_args function can handle const vector<string>&, because we

### DIFF
--- a/optparse/optparse.cc
+++ b/optparse/optparse.cc
@@ -636,18 +636,18 @@ auto OptionParser::invalid_args_to_str() -> string {
     return output;
 }
 
-auto OptionParser::invalid_argc() -> int { return static_cast<int>(_invalid_args.size() + 1); }
+auto OptionParser::invalid_argc(const vector<string>& invalid_args) -> int { return static_cast<int>(invalid_args.size() + 1); }
 
-auto OptionParser::get_invalid_argv() -> std::unique_ptr<char*[]> { // NOLINT(modernize-avoid-c-arrays)
-    auto argc = _invalid_args.size();
+auto OptionParser::get_invalid_argv(const char* argv0, const vector<string>& invalid_args) -> std::unique_ptr<const char*[]> { // NOLINT(modernize-avoid-c-arrays)
+    auto argc = invalid_args.size();
     if (argc == 0) {
         return {nullptr};
     }
     // create a new array of char* with argc + 1: flag_num + program
-    auto argv = std::make_unique<char*[]>(argc + 1);  // NOLINT(modernize-avoid-c-arrays)
-    argv[0] = _program.data();
+    auto argv = std::make_unique<const char*[]>(argc + 1);  // NOLINT(modernize-avoid-c-arrays)
+    argv[0] = argv0;  // NOLINT(cppcoreguidelines-pro-type-const-cast)
     for (size_t i = 0; i < argc; ++i) {
-        argv[i + 1] = _invalid_args[i].data();
+        argv[i + 1] = invalid_args[i].data();
     }
     return argv;
 }

--- a/optparse/optparse.hpp
+++ b/optparse/optparse.hpp
@@ -378,9 +378,9 @@ class OptionParser
 
     [[nodiscard]] auto invalid_args_to_str() -> string;
 
-    [[nodiscard]] auto invalid_argc() -> int;
+    [[nodiscard]] static auto invalid_argc(const vector<string>& invalid_args) -> int;
 
-    [[nodiscard]] auto get_invalid_argv() -> std::unique_ptr<char*[]>; // NOLINT(modernize-avoid-c-arrays)
+    [[nodiscard]] static auto get_invalid_argv(const char* argv0, const vector<string>& invalid_args) -> std::unique_ptr<const char*[]>; // NOLINT(modernize-avoid-c-arrays)
 
     [[nodiscard]] auto has_value_to_process(string current_arg, const ArgList& args) const -> bool;
 };

--- a/test/optparse_test.cc
+++ b/test/optparse_test.cc
@@ -77,9 +77,9 @@ TEST_CASE("optparser::smoke") {
     CHECK_EQ(invalid_args[0], "-cconfig.txt");
 
     CHECK_EQ(parser.invalid_args_to_str(), "-cconfig.txt");
-    CHECK_EQ(parser.invalid_argc(), 2);
-    CHECK_EQ(strcmp(parser.get_invalid_argv()[0], "test"), 0);
-    CHECK_EQ(strcmp(parser.get_invalid_argv()[1], "-cconfig.txt"), 0);
+    CHECK_EQ(parser.invalid_argc(invalid_args), 2);
+    CHECK_EQ(strcmp(parser.get_invalid_argv("test", invalid_args)[0], "test"), 0);
+    CHECK_EQ(strcmp(parser.get_invalid_argv("test", invalid_args)[1], "-cconfig.txt"), 0);
 
 }
 


### PR DESCRIPTION
need use the invalid_args after the expiration of Optparse