### PR TITLE
string_core checking code about cross-thread copy/move/clone

### DIFF
--- a/string/arena_string.hpp
+++ b/string/arena_string.hpp
@@ -105,7 +105,6 @@ class arena_string_core
     auto operator=(arena_string_core&&) -> arena_string_core& = delete;
 
     arena_string_core(arena_string_core&& goner) noexcept : allocator_(std::move(goner.allocator_)) {
-
         // move just work same as normal
 #ifndef NDEBUG
         cpu_ = std::move(goner.cpu_);  // NOLINT

--- a/string/string.hpp
+++ b/string/string.hpp
@@ -37,10 +37,9 @@
 #include <limits>            // for numeric_limits
 #include <memory>            // for allocator_traits
 #include <new>               // for bad_alloc, operator new
-#include <optional>
-#include <stdexcept>    // for out_of_range, length_error, logic_e...
-#include <string>       // for basic_string, allocator, string
-#include <string_view>  // for hash, basic_string_view
+#include <stdexcept>         // for out_of_range, length_error, logic_e...
+#include <string>            // for basic_string, allocator, string
+#include <string_view>       // for hash, basic_string_view
 #include <thread>
 #include <type_traits>  // for integral_constant, true_type, is_same
 #include <utility>      // for move, make_pair, pair
@@ -48,6 +47,7 @@
 #include "arena/arenahelper.hpp"
 #include "assert_config.hpp"
 #include "xxhash.h"  // for XXH32
+#include <optional>
 
 namespace stdb::memory {
 
@@ -361,6 +361,7 @@ class string_core
     auto operator=(const string_core& rhs) -> string_core& = delete;
 
     string_core(string_core&& goner) noexcept {
+
         // move just work same as normal
 #ifndef NDEBUG
         cpu_ = std::move(goner.cpu_);  // NOLINT
@@ -369,6 +370,7 @@ class string_core
         ml_ = goner.ml_;
         // Clean goner's carcass
         goner.reset();
+
     }
     auto operator=(string_core&& rhs) -> string_core& = delete;
 
@@ -429,6 +431,9 @@ class string_core
         auto const t = ml_;
         ml_ = rhs.ml_;
         rhs.ml_ = t;
+#ifndef NDEBUG
+        std::swap(cpu_, rhs.cpu_);
+#endif
     }
 
     // In C++11 data() and c_str() are 100% equivalent.
@@ -1189,7 +1194,7 @@ class basic_string
         // new rst is a new string, so rst.store_.cpu_ should be kNullCPU.
         rst.store_.cpu_ = std::nullopt;
         return rst;
-#else
+#else 
         // directly call copy constructor.
         // and use the RVO to avoid copy or move.
         return {*this};

--- a/string/string.hpp
+++ b/string/string.hpp
@@ -37,9 +37,10 @@
 #include <limits>            // for numeric_limits
 #include <memory>            // for allocator_traits
 #include <new>               // for bad_alloc, operator new
-#include <stdexcept>         // for out_of_range, length_error, logic_e...
-#include <string>            // for basic_string, allocator, string
-#include <string_view>       // for hash, basic_string_view
+#include <optional>
+#include <stdexcept>    // for out_of_range, length_error, logic_e...
+#include <string>       // for basic_string, allocator, string
+#include <string_view>  // for hash, basic_string_view
 #include <thread>
 #include <type_traits>  // for integral_constant, true_type, is_same
 #include <utility>      // for move, make_pair, pair
@@ -47,7 +48,6 @@
 #include "arena/arenahelper.hpp"
 #include "assert_config.hpp"
 #include "xxhash.h"  // for XXH32
-#include <optional>
 
 namespace stdb::memory {
 
@@ -361,7 +361,6 @@ class string_core
     auto operator=(const string_core& rhs) -> string_core& = delete;
 
     string_core(string_core&& goner) noexcept {
-
         // move just work same as normal
 #ifndef NDEBUG
         cpu_ = std::move(goner.cpu_);  // NOLINT
@@ -370,7 +369,6 @@ class string_core
         ml_ = goner.ml_;
         // Clean goner's carcass
         goner.reset();
-
     }
     auto operator=(string_core&& rhs) -> string_core& = delete;
 
@@ -1194,7 +1192,7 @@ class basic_string
         // new rst is a new string, so rst.store_.cpu_ should be kNullCPU.
         rst.store_.cpu_ = std::nullopt;
         return rst;
-#else 
+#else
         // directly call copy constructor.
         // and use the RVO to avoid copy or move.
         return {*this};

--- a/string/string.hpp
+++ b/string/string.hpp
@@ -37,9 +37,10 @@
 #include <limits>            // for numeric_limits
 #include <memory>            // for allocator_traits
 #include <new>               // for bad_alloc, operator new
-#include <stdexcept>         // for out_of_range, length_error, logic_e...
-#include <string>            // for basic_string, allocator, string
-#include <string_view>       // for hash, basic_string_view
+#include <optional>
+#include <stdexcept>    // for out_of_range, length_error, logic_e...
+#include <string>       // for basic_string, allocator, string
+#include <string_view>  // for hash, basic_string_view
 #include <thread>
 #include <type_traits>  // for integral_constant, true_type, is_same
 #include <utility>      // for move, make_pair, pair
@@ -328,6 +329,17 @@ class string_core
 
     string_core(const string_core& rhs) noexcept {
         Assert(&rhs != this);
+        // make sure all copy occur in same thread, or from a unshared string
+        // if rhs is a unshared string, set the cpu_ to current thread_id
+#ifndef NDEBUG
+        auto thread_id = std::this_thread::get_id();
+        Assert(not rhs.cpu_.has_value() or rhs.cpu_.value() == thread_id);
+        // thread::id class do not has operator =, so no overwrite occurs in any case.
+        if (not rhs.cpu_.has_value()) {
+            cpu_ = thread_id;
+            rhs.cpu_ = thread_id;
+        }
+#endif
         switch (rhs.category()) {
             case Category::isSmall:
                 copySmall(rhs);
@@ -336,6 +348,7 @@ class string_core
                 copyMedium(rhs);
                 break;
             case Category::isLarge:
+                // forbid cross thread copy for Large, refCount++/-- over cross is not safe.
                 copyLarge(rhs);
                 break;
             default:
@@ -348,6 +361,10 @@ class string_core
     auto operator=(const string_core& rhs) -> string_core& = delete;
 
     string_core(string_core&& goner) noexcept {
+        // move just work same as normal
+#ifndef NDEBUG
+        cpu_ = std::move(goner.cpu_);  // NOLINT
+#endif
         // Take goner's guts
         ml_ = goner.ml_;
         // Clean goner's carcass
@@ -371,7 +388,8 @@ class string_core
 
     ~string_core() noexcept {
 #ifndef NDEBUG
-        Assert(std::this_thread::get_id() == cpu_);
+        auto thread_id = std::this_thread::get_id();
+        Assert(not cpu_.has_value() or thread_id == cpu_.value());
 #endif
 
         if (category() == Category::isSmall) {
@@ -646,7 +664,7 @@ class string_core
 
 // thread_id for contention checking in debug mode
 #ifndef NDEBUG
-    std::thread::id cpu_ = std::this_thread::get_id();
+    mutable std::optional<std::thread::id> cpu_ = std::nullopt;
 #endif
 
     constexpr static size_t lastChar = sizeof(MediumLarge) - 1;
@@ -739,7 +757,7 @@ template <class Char>
 inline void string_core<Char>::initSmall(const Char* const data, const size_t size) noexcept {
 // Layout is: Char* data_, size_t size_, size_t capacity_
 #ifndef NDEBUG
-    static_assert(sizeof(*this) == sizeof(Char*) + 2 * sizeof(size_t) + sizeof(std::thread::id),
+    static_assert(sizeof(*this) == sizeof(Char*) + 2 * sizeof(size_t) + sizeof(std::optional<std::thread::id>),
                   "string has unexpected size");
 #else
     static_assert(sizeof(*this) == sizeof(Char*) + 2 * sizeof(size_t), "string has unexpected size");
@@ -1148,14 +1166,34 @@ class basic_string
      * refCounted ++/-- is not thread safe.
      */
     [[nodiscard]] auto clone() const -> basic_string {
+#ifndef NDEBUG
+        // just copy the optional<std::thread::id>
+        std::optional<std::thread::id> origin_cpu = store_.cpu_;
+#endif
         if (store_.category() == Storage::Category::isLarge) {
             // call copy constructor
             basic_string rst(*this);
             rst.store_.unshare();
+
+            // restore cpu_ and new store_.cpu_, because clone is not copy.
+#ifndef NDEBUG
+            store_.cpu_.swap(origin_cpu);
+            // new rst is a new string, so rst.store_.cpu_ should be std::nullopt;
+            rst.store_.cpu_ = std::nullopt;
+#endif
             return rst;
         }
+#ifndef NDEBUG
+        basic_string rst{*this};
+        store_.cpu_.swap(origin_cpu);
+        // new rst is a new string, so rst.store_.cpu_ should be kNullCPU.
+        rst.store_.cpu_ = std::nullopt;
+        return rst;
+#else
         // directly call copy constructor.
+        // and use the RVO to avoid copy or move.
         return {*this};
+#endif
     }
 
     operator std::basic_string_view<value_type, traits_type>() const noexcept { return {data(), size()}; }

--- a/test/stdb_vector_test.cc
+++ b/test/stdb_vector_test.cc
@@ -1121,7 +1121,7 @@ TEST_CASE("Hilbert::stdb_vector::memory::string") {
         vec.push_back("hello");
         CHECK_EQ(vec.capacity(), kFastVectorDefaultCapacity / sizeof(memory::string));
         vec.push_back("world");
-            CHECK_EQ(vec.capacity(), 2);
+        CHECK_EQ(vec.capacity(), 2);
         vec.push_back("!");
         CHECK_GT(vec.capacity(), kFastVectorDefaultCapacity / sizeof(memory::string));
     }

--- a/test/stdb_vector_test.cc
+++ b/test/stdb_vector_test.cc
@@ -1121,7 +1121,7 @@ TEST_CASE("Hilbert::stdb_vector::memory::string") {
         vec.push_back("hello");
         CHECK_EQ(vec.capacity(), kFastVectorDefaultCapacity / sizeof(memory::string));
         vec.push_back("world");
-        CHECK_EQ(vec.capacity(), kFastVectorDefaultCapacity / sizeof(memory::string));
+            CHECK_EQ(vec.capacity(), 2);
         vec.push_back("!");
         CHECK_GT(vec.capacity(), kFastVectorDefaultCapacity / sizeof(memory::string));
     }

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -3263,7 +3263,20 @@ TEST_CASE("string::clone") {
     string origin_small_duplicated(origin_small);
 
     // NOTICE: passed by ref cross thread is not a good practice
+    std::thread t1([&, new_origin_small = origin_small.clone()]() {
+        // new_origin_small.append("0");
+        std::cout << new_origin_small << std::endl;
+    });
+    t1.join();
+}
+
+TEST_CASE("string::clone-then-move") {
+    string origin_small("123456789");
+    string origin_small_duplicated(origin_small);
+
+    // NOTICE: passed by ref cross thread is not a good practice
     std::thread t1([&, new_origin_small = origin_small.clone()]() mutable {
+        auto moved_small = std::move(new_origin_small);
         new_origin_small.append("0");
         std::cout << new_origin_small << std::endl;
     });

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -3167,6 +3167,60 @@ TEST_CASE("arena_string::testAllClauses") {
     TEST_CLAUSE_ARENA(21_4_8_1_l);
     TEST_CLAUSE_ARENA(21_4_8_9_a);
 }
+// following testcases can check cross cpu check correctly.
+
+TEST_CASE("string::cross_cpu_check_will_ignore_small_string") {
+    /*
+    SUBCASE("small") {
+        string origin_small("123456789");
+        // NOTICE: passed by ref cross thread is not a good practice
+        std::thread t1([&origin_small]() {
+            string copied_origin{origin_small};
+            copied_origin.append("0");
+            std::cout << copied_origin << std::endl;
+        });
+        t1.join();
+    }
+    SUBCASE("median") {
+        string origin_median("1234567890123456789012345678901234567890");
+        // NOTICE: passed by ref cross thread is not a good practice
+        std::thread t2([&origin_median]() {
+            string copied_origin{origin_median};
+            copied_origin.append("0");
+            std::cout << copied_origin << std::endl;
+        });
+        t2.join();
+    }
+    // keep comment out this case, it will cause assert failure and crash.
+    SUBCASE("large") {
+        string origin_large("1234567890123456789012345678901234567890");
+        for (int i = 0; i < 125; ++i) {
+            origin_large.append("1234567890123456789012345678901234567890");
+        }
+        // NOTICE: passed by ref cross thread is not a good practice
+        std::thread t3([&origin_large]() {
+            string copied_origin{origin_large};
+            // cross thread copy a large
+            copied_origin.append("0");
+            std::cout << copied_origin << std::endl;
+        });
+        t3.join();
+    }
+    */
+}
+
+TEST_CASE("string::cross move can not accept large string that shared") {
+    SUBCASE("small") {
+        string origin_small("123456789");
+        // NOTICE: passed by ref cross thread is not a good practice
+        std::thread t1([origin_small]() mutable {
+            string copied_origin{std::move(origin_small)};
+            copied_origin.append("0");
+            std::cout << copied_origin << std::endl;
+        });
+        t1.join();
+    }
+}
 
 // uncomment this case will cause assert failure and crash.
 /*


### PR DESCRIPTION
这里的核心思路如下：
一个没有被 copy 过的 str 是没有 thread id 存储的，就是 std::nulllopt, 直到被 copy，move 不改变thread_id
所以，cross core 的用法只有 2 个是合法的，一个从来没有被 copy 过的 str，或者 clone 一个新的 str 出来，然后move 进新的 thread 里，在 dstr 的时候就没有问题。如果你直接 copy，那么 dstr 一定会出问题。
虽然对于一个 small str 来说，怎么 copy  都没有问题，但是 str 大小是运行期决定的，测试期不能确保有足够的数据，所以，一视同仁。

arena_string 还没有改完。